### PR TITLE
Allow read only access for schedules

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,7 +8,7 @@ Developers
 * Helen Sherwood-Taylor - https://github.com/helenst
 * Tushar Gupta - https://github.com/Tushar-Gupta
 * Matheus Zorzete Marchiore - https://github.com/marchiore
-
+* Laszlo Ratsko - https://github.com/rlaszlo
 
 Translators
 -----------

--- a/wger/manager/templates/schedule/view.html
+++ b/wger/manager/templates/schedule/view.html
@@ -2,6 +2,15 @@
 {% load i18n %}
 {% load staticfiles wger_extras %}
 
+{#           #}
+{# Opengraph #}
+{#           #}
+{% block opengraph %}
+    {{ block.super }}
+    <meta property="og:title" content="{% trans 'Schedule' %}">
+    <meta property="og:description" content="{{ schedule }} / {{owner_user.username}}">
+{% endblock %}
+
 {% block title %}{{schedule.name}}{% endblock %}
 
 {% block header %}
@@ -86,7 +95,9 @@ $(function() {
     <thead>
     <tr>
         <th>{% trans "Nr." %}</th>
+        {% if is_owner %}
         <th>{% trans "Actions" %}</th>
+        {% endif %}
         <th>{% trans "Workout" %}</th>
         <th>{% trans "Weeks" %}</th>
     </tr>
@@ -97,6 +108,7 @@ $(function() {
         <td>
             {{ forloop.counter }}
         </td>
+        {% if is_owner %}
         <td style="min-width: 6em;">
             <span class="editoptions">
                 <img src="{% static 'images/icons/move.svg' %}"
@@ -121,6 +133,7 @@ $(function() {
                              alt="{% trans 'Delete' %}"></a>
             </span>
         </td>
+        {% endif %}
         <td>
             <a href="{{ step.workout.get_absolute_url }}">{{ step.workout }}</a>
             {% if active_workout == step %}
@@ -132,6 +145,7 @@ $(function() {
         </td>
     </tr>
     {% empty %}
+    {% if is_owner %}
     <tr>
         <td colspan="4">
             <a href="{% url 'manager:step:add' schedule.id %}" class="wger-modal-dialog btn btn-block btn-default">
@@ -139,7 +153,9 @@ $(function() {
             </a>
         </td>
     </tr>
+    {% endif %}
     {% endfor %}
+    {% if is_owner %}
     <tr>
         <td colspan="4">
             {% if not schedule.is_active %}
@@ -157,6 +173,7 @@ $(function() {
         <td colspan="2">
         </td>
     </tr>
+    {% endif %}
     </tbody>
 </table>
 </div>
@@ -205,11 +222,13 @@ $(function() {
 
 
 {% block sidebar %}
+{% if is_owner %}
 <h3>{% trans "Adding workouts" %}</h3>
 
 <p>{% blocktrans %}Add as many workouts to the schedule as you want. You can
 edit the order per drag-and-drop. It's also possible to add one workout more
 than once.{% endblocktrans %}</p>
+{% endif %}
 
 <h3>{% trans "Options" %}</h3>
 <p>
@@ -231,7 +250,7 @@ than once.{% endblocktrans %}</p>
     title="{% trans 'Download as PDF' %}">
 {% trans "Download as PDF" %}</a>
 </p>
-
+{% if is_owner %}
 <p>
 <a href="{% url 'manager:schedule:edit' schedule.id %}"
    class="wger-modal-dialog">
@@ -253,7 +272,7 @@ than once.{% endblocktrans %}</p>
     title="{% trans 'Delete schedule' %}">
 {% trans "Delete schedule" %}</a>
 </p>
-
+{% endif %}
 
 <div class="modal fade" id="export-ical-popup">
     <div class="modal-dialog">

--- a/wger/manager/tests/test_schedule.py
+++ b/wger/manager/tests/test_schedule.py
@@ -33,6 +33,65 @@ from wger.utils.helpers import make_token
 
 logger = logging.getLogger(__name__)
 
+class ScheduleShareButtonTestCase(WorkoutManagerTestCase):
+    '''
+    Test that the share button is correctly displayed and hidden
+    '''
+
+    def test_share_button(self):
+        workout = Workout.objects.get(pk=2)
+
+        response = self.client.get(workout.get_absolute_url())
+        self.assertFalse(response.context['show_shariff'])
+
+        self.user_login('admin')
+        response = self.client.get(workout.get_absolute_url())
+        self.assertTrue(response.context['show_shariff'])
+
+        self.user_login('test')
+        response = self.client.get(workout.get_absolute_url())
+        self.assertFalse(response.context['show_shariff'])
+
+class ScheduleAccessTestCase(WorkoutManagerTestCase):
+    '''
+    Test accessing the workout page
+    '''
+
+    def test_access_shared(self):
+        '''
+        Test accessing the URL of a shared workout
+        '''
+        workout = Schedule.objects.get(pk=2)
+
+        self.user_login('admin')
+        response = self.client.get(workout.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+
+        self.user_login('test')
+        response = self.client.get(workout.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+
+        self.user_logout()
+        response = self.client.get(workout.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+
+    def test_access_not_shared(self):
+        '''
+        Test accessing the URL of a private workout
+        '''
+        workout = Schedule.objects.get(pk=1)
+
+        self.user_login('admin')
+        response = self.client.get(workout.get_absolute_url())
+        self.assertEqual(response.status_code, 403)
+
+        self.user_login('test')
+        response = self.client.get(workout.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+
+        self.user_logout()
+        response = self.client.get(workout.get_absolute_url())
+        self.assertEqual(response.status_code, 403)
 
 class ScheduleRepresentationTestCase(WorkoutManagerTestCase):
     '''
@@ -93,25 +152,22 @@ class ScheduleTestCase(WorkoutManagerTestCase):
     Other tests
     '''
 
-    def schedule_detail_page(self, fail=False):
+    def schedule_detail_page(self):
         '''
         Helper function
         '''
 
         response = self.client.get(reverse('manager:schedule:view', kwargs={'pk': 2}))
-        if fail:
-            self.assertIn(response.status_code, STATUS_CODES_FAIL)
-        else:
-            self.assertEqual(response.status_code, 200)
-            self.assertContains(response, 'This schedule is a loop')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'This schedule is a loop')
 
-            schedule = Schedule.objects.get(pk=2)
-            schedule.is_loop = False
-            schedule.save()
+        schedule = Schedule.objects.get(pk=2)
+        schedule.is_loop = False
+        schedule.save()
 
-            response = self.client.get(reverse('manager:schedule:view', kwargs={'pk': 2}))
-            self.assertEqual(response.status_code, 200)
-            self.assertNotContains(response, 'This schedule is a loop')
+        response = self.client.get(reverse('manager:schedule:view', kwargs={'pk': 2}))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'This schedule is a loop')
 
     def test_schedule_detail_page_owner(self):
         '''
@@ -120,14 +176,6 @@ class ScheduleTestCase(WorkoutManagerTestCase):
 
         self.user_login()
         self.schedule_detail_page()
-
-    def test_schedule_detail_page_other(self):
-        '''
-        Tests the schedule detail page as a different user
-        '''
-
-        self.user_login('test')
-        self.schedule_detail_page(fail=True)
 
     def test_schedule_overview(self):
         '''

--- a/wger/manager/views/schedule.py
+++ b/wger/manager/views/schedule.py
@@ -64,16 +64,20 @@ def overview(request):
     return render(request, 'schedule/overview.html', template_data)
 
 
-@login_required
 def view(request, pk):
     '''
     Show the workout schedule
     '''
     template_data = {}
-    user = request.user
+    schedule = get_object_or_404(Schedule, pk=pk)
+    user = schedule.user
+    is_owner = request.user == user
+
+    if not is_owner and not user.userprofile.ro_access:
+        return HttpResponseForbidden()
+
     uid, token = make_token(user)
 
-    schedule = get_object_or_404(Schedule, pk=pk, user=user)
     template_data['schedule'] = schedule
     if schedule.is_active:
         template_data['active_workout'] = schedule.get_current_scheduled_workout()
@@ -84,6 +88,8 @@ def view(request, pk):
 
     template_data['uid'] = uid
     template_data['token'] = token
+    template_data['is_owner'] = is_owner
+    template_data['owner_user'] = user
 
     return render(request, 'schedule/view.html', template_data)
 

--- a/wger/manager/views/schedule.py
+++ b/wger/manager/views/schedule.py
@@ -90,6 +90,7 @@ def view(request, pk):
     template_data['token'] = token
     template_data['is_owner'] = is_owner
     template_data['owner_user'] = user
+    template_data['show_shariff'] = is_owner
 
     return render(request, 'schedule/view.html', template_data)
 


### PR DESCRIPTION
Removed the login_required decorator from the schedule view
and check for the read only access settings.

The edit buttons and the content visible only for the logged in
users is also wrapped in conditions.

Added the open graph meta tags like in the workout view.