### PR TITLE
Drf 3 upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ sphinx
 django-sortedm2m
 
 # REST API
-djangorestframework==3.1.3
+djangorestframework>=3.1,<3.2
 django-filter
 django-tastypie
 django-cors-headers

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ sphinx
 django-sortedm2m
 
 # REST API
-djangorestframework==2.3.13
+djangorestframework==3.1.3
 django-filter
 django-tastypie
 django-cors-headers

--- a/wger/core/api/serializers.py
+++ b/wger/core/api/serializers.py
@@ -17,7 +17,7 @@
 
 from rest_framework import serializers
 
-from wger.core.models import UserProfile
+from wger.core.models import UserProfile, Language, DaysOfWeek, License
 
 
 class UserprofileSerializer(serializers.ModelSerializer):
@@ -33,3 +33,27 @@ class UsernameSerializer(serializers.Serializer):
     Serializer to extract the username
     '''
     username = serializers.CharField()
+
+
+class LanguageSerializer(serializers.ModelSerializer):
+    '''
+    Language serializer
+    '''
+    class Meta:
+        model = Language
+
+
+class DaysOfWeekSerializer(serializers.ModelSerializer):
+    '''
+    DaysOfWeek serializer
+    '''
+    class Meta:
+        model = DaysOfWeek
+
+
+class LicenseSerializer(serializers.ModelSerializer):
+    '''
+    License serializer
+    '''
+    class Meta:
+        model = License

--- a/wger/core/api/views.py
+++ b/wger/core/api/views.py
@@ -24,7 +24,7 @@ from wger.core.models import UserProfile
 from wger.core.models import Language
 from wger.core.models import DaysOfWeek
 from wger.core.models import License
-from wger.core.api.serializers import UsernameSerializer
+from wger.core.api.serializers import UsernameSerializer, LanguageSerializer, DaysOfWeekSerializer, LicenseSerializer
 from wger.core.api.serializers import UserprofileSerializer
 from wger.utils.permissions import UpdateOnlyPermission
 from wger.utils.permissions import WgerPermission
@@ -66,7 +66,8 @@ class LanguageViewSet(viewsets.ReadOnlyModelViewSet):
     '''
     API endpoint for workout objects
     '''
-    model = Language
+    queryset = Language.objects.all()
+    serializer_class = LanguageSerializer
     ordering_fields = '__all__'
     filter_fields = ('full_name',
                      'short_name')
@@ -76,7 +77,8 @@ class DaysOfWeekViewSet(viewsets.ReadOnlyModelViewSet):
     '''
     API endpoint for workout objects
     '''
-    model = DaysOfWeek
+    queryset = DaysOfWeek.objects.all()
+    serializer_class = DaysOfWeekSerializer
     ordering_fields = '__all__'
     filter_fields = ('day_of_week', )
 
@@ -85,7 +87,8 @@ class LicenseViewSet(viewsets.ReadOnlyModelViewSet):
     '''
     API endpoint for workout objects
     '''
-    model = License
+    queryset = License.objects.all()
+    serializer_class = LicenseSerializer
     ordering_fields = '__all__'
     filter_fields = ('full_name',
                      'short_name',

--- a/wger/core/api/views.py
+++ b/wger/core/api/views.py
@@ -34,7 +34,6 @@ class UserProfileViewSet(viewsets.ModelViewSet):
     '''
     API endpoint for workout objects
     '''
-    model = UserProfile
     is_private = True
     serializer_class = UserprofileSerializer
     permission_classes = (WgerPermission, UpdateOnlyPermission)

--- a/wger/core/api/views.py
+++ b/wger/core/api/views.py
@@ -24,7 +24,8 @@ from wger.core.models import UserProfile
 from wger.core.models import Language
 from wger.core.models import DaysOfWeek
 from wger.core.models import License
-from wger.core.api.serializers import UsernameSerializer, LanguageSerializer, DaysOfWeekSerializer, LicenseSerializer
+from wger.core.api.serializers import UsernameSerializer, LanguageSerializer, \
+    DaysOfWeekSerializer, LicenseSerializer
 from wger.core.api.serializers import UserprofileSerializer
 from wger.utils.permissions import UpdateOnlyPermission
 from wger.utils.permissions import WgerPermission

--- a/wger/core/api/views.py
+++ b/wger/core/api/views.py
@@ -18,7 +18,7 @@
 from django.contrib.auth.models import User
 from rest_framework import viewsets
 from rest_framework.response import Response
-from rest_framework.decorators import link
+from rest_framework.decorators import detail_route
 
 from wger.core.models import UserProfile
 from wger.core.models import Language
@@ -52,7 +52,7 @@ class UserProfileViewSet(viewsets.ModelViewSet):
         '''
         return [(User, 'user')]
 
-    @link()
+    @detail_route()
     def username(self, request, pk):
         '''
         Return the username

--- a/wger/core/templates/rest_framework/api.html
+++ b/wger/core/templates/rest_framework/api.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load rest_framework %}
 {% load wger_extras %}
-{% load wger_extras %}
+{% load static %}
 
 {% block header %}
 <link rel="stylesheet" type="text/css" href="{% static 'rest_framework/css/prettify.css' %}"/>

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -15,7 +15,8 @@
 # You should have received a copy of the GNU Affero General Public License
 
 from rest_framework import serializers
-from wger.exercises.models import Muscle, Exercise, ExerciseImage, ExerciseCategory, Equipment, ExerciseComment
+from wger.exercises.models import Muscle, Exercise, ExerciseImage, \
+    ExerciseCategory, Equipment, ExerciseComment
 
 
 class ExerciseSerializer(serializers.ModelSerializer):
@@ -32,6 +33,7 @@ class EquipmentSerializer(serializers.ModelSerializer):
     '''
     class Meta:
         model = Equipment
+
 
 class ExerciseCategorySerializer(serializers.ModelSerializer):
     '''

--- a/wger/exercises/api/serializers.py
+++ b/wger/exercises/api/serializers.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of wger Workout Manager.
+#
+# wger Workout Manager is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# wger Workout Manager is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+
+from rest_framework import serializers
+from wger.exercises.models import Muscle, Exercise, ExerciseImage, ExerciseCategory, Equipment, ExerciseComment
+
+
+class ExerciseSerializer(serializers.ModelSerializer):
+    '''
+    Exercise serializer
+    '''
+    class Meta:
+        model = Exercise
+
+
+class EquipmentSerializer(serializers.ModelSerializer):
+    '''
+    Equipment serializer
+    '''
+    class Meta:
+        model = Equipment
+
+class ExerciseCategorySerializer(serializers.ModelSerializer):
+    '''
+    ExerciseCategory serializer
+    '''
+    class Meta:
+        model = ExerciseCategory
+
+
+class ExerciseImageSerializer(serializers.ModelSerializer):
+    '''
+    ExerciseImage serializer
+    '''
+    class Meta:
+        model = ExerciseImage
+
+
+class ExerciseCommentSerializer(serializers.ModelSerializer):
+    '''
+    ExerciseComment serializer
+    '''
+    class Meta:
+        model = ExerciseComment
+
+
+class MuscleSerializer(serializers.ModelSerializer):
+    '''
+    Muscle serializer
+    '''
+    class Meta:
+        model = Muscle

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -27,6 +27,8 @@ from easy_thumbnails.files import get_thumbnailer
 from django.utils.translation import ugettext as _
 
 from wger.config.models import LanguageConfig
+from wger.exercises.api.serializers import MuscleSerializer, ExerciseSerializer, ExerciseImageSerializer, \
+    ExerciseCategorySerializer, EquipmentSerializer, ExerciseCommentSerializer
 from wger.exercises.models import Exercise
 from wger.exercises.models import Equipment
 from wger.exercises.models import ExerciseCategory
@@ -43,6 +45,7 @@ class ExerciseViewSet(viewsets.ModelViewSet):
     API endpoint for exercise objects
     '''
     model = Exercise
+    serializer_class = ExerciseSerializer
     permission_classes = (IsAuthenticatedOrReadOnly, CreateOnlyPermission)
     ordering_fields = '__all__'
     filter_fields = ('category',
@@ -110,7 +113,8 @@ class EquipmentViewSet(viewsets.ReadOnlyModelViewSet):
     '''
     API endpoint for equipment objects
     '''
-    model = Equipment
+    queryset = Equipment.objects.all()
+    serializer_class = EquipmentSerializer
     ordering_fields = '__all__'
     filter_fields = ('name',)
 
@@ -119,7 +123,8 @@ class ExerciseCategoryViewSet(viewsets.ReadOnlyModelViewSet):
     '''
     API endpoint for exercise categories objects
     '''
-    model = ExerciseCategory
+    queryset = ExerciseCategory.objects.all()
+    serializer_class = ExerciseCategorySerializer
     ordering_fields = '__all__'
     filter_fields = ('name',)
 
@@ -129,6 +134,7 @@ class ExerciseImageViewSet(viewsets.ModelViewSet):
     API endpoint for exercise image objects
     '''
     model = ExerciseImage
+    serializer_class = ExerciseImageSerializer
     permission_classes = (IsAuthenticatedOrReadOnly, CreateOnlyPermission)
     ordering_fields = '__all__'
     filter_fields = ('is_main',
@@ -162,7 +168,8 @@ class ExerciseCommentViewSet(viewsets.ReadOnlyModelViewSet):
     '''
     API endpoint for exercise comment objects
     '''
-    model = ExerciseComment
+    queryset = ExerciseComment.objects.all()
+    serializer_class = ExerciseCommentSerializer
     ordering_fields = '__all__'
     filter_fields = ('comment',
                      'exercise')
@@ -172,7 +179,8 @@ class MuscleViewSet(viewsets.ReadOnlyModelViewSet):
     '''
     API endpoint for muscle objects
     '''
-    model = Muscle
+    queryset = Muscle.objects.all()
+    serializer_class = MuscleSerializer
     ordering_fields = '__all__'
     filter_fields = ('name',
                      'is_front')

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -18,7 +18,7 @@
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
-from rest_framework.decorators import link
+from rest_framework.decorators import detail_route
 from rest_framework.decorators import api_view
 
 from easy_thumbnails.alias import aliases
@@ -137,7 +137,7 @@ class ExerciseImageViewSet(viewsets.ModelViewSet):
                      'license',
                      'license_author')
 
-    @link()
+    @detail_route()
     def thumbnails(self, request, pk):
         '''
         Return a list of the image's thumbnails

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -60,12 +60,15 @@ class ExerciseViewSet(viewsets.ModelViewSet):
                      'license',
                      'license_author')
 
-    def pre_save(self, obj):
+    def perform_create(self, serializer):
         '''
-        Set language, author and status
+        Set author and status
         '''
-        obj.language = load_language()
+        language = load_language()
+        obj = serializer.save(language=language)
+        # Todo is it right to call set author after save?
         obj.set_author(self.request)
+        obj.save()
 
 
 @api_view(['GET'])
@@ -156,11 +159,14 @@ class ExerciseImageViewSet(viewsets.ModelViewSet):
         thumbnails['original'] = image.image.url
         return Response(thumbnails)
 
-    def pre_save(self, obj):
+    def perform_create(self, serializer):
         '''
         Set the license data
         '''
+        obj = serializer.save()
+        # Todo is it right to call set author after save?
         obj.set_author(self.request)
+        obj.save()
 
 
 class ExerciseCommentViewSet(viewsets.ReadOnlyModelViewSet):

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -27,8 +27,9 @@ from easy_thumbnails.files import get_thumbnailer
 from django.utils.translation import ugettext as _
 
 from wger.config.models import LanguageConfig
-from wger.exercises.api.serializers import MuscleSerializer, ExerciseSerializer, ExerciseImageSerializer, \
-    ExerciseCategorySerializer, EquipmentSerializer, ExerciseCommentSerializer
+from wger.exercises.api.serializers import MuscleSerializer, ExerciseSerializer, \
+    ExerciseImageSerializer, ExerciseCategorySerializer, EquipmentSerializer, \
+    ExerciseCommentSerializer
 from wger.exercises.models import Exercise
 from wger.exercises.models import Equipment
 from wger.exercises.models import ExerciseCategory

--- a/wger/exercises/api/views.py
+++ b/wger/exercises/api/views.py
@@ -44,7 +44,6 @@ class ExerciseViewSet(viewsets.ModelViewSet):
     '''
     API endpoint for exercise objects
     '''
-    model = Exercise
     serializer_class = ExerciseSerializer
     permission_classes = (IsAuthenticatedOrReadOnly, CreateOnlyPermission)
     ordering_fields = '__all__'
@@ -133,7 +132,6 @@ class ExerciseImageViewSet(viewsets.ModelViewSet):
     '''
     API endpoint for exercise image objects
     '''
-    model = ExerciseImage
     serializer_class = ExerciseImageSerializer
     permission_classes = (IsAuthenticatedOrReadOnly, CreateOnlyPermission)
     ordering_fields = '__all__'

--- a/wger/manager/api/serializers.py
+++ b/wger/manager/api/serializers.py
@@ -115,10 +115,20 @@ class WorkoutCanonicalFormExerciseSerializer(serializers.Serializer):
     Serializer for an exercise in the canonical form of a workout
     '''
     obj = SetSerializer()
-    exercise_list = WorkoutCanonicalFormExerciseListSerializer()
+    exercise_list = WorkoutCanonicalFormExerciseListSerializer(many=True)
     has_settings = serializers.BooleanField()
     is_superset = serializers.BooleanField()
     muscles = serializers.ReadOnlyField()
+
+
+class DaysOfWeekCanonicalFormSerializer(serializers.Serializer):
+    '''
+    Serializer for a days of week in the canonical form of a workout
+    '''
+    text = serializers.ReadOnlyField()
+    day_list = serializers.ListField(
+        child=serializers.CharField()
+    )
 
 
 class DayCanonicalFormSerializer(serializers.Serializer):
@@ -127,7 +137,7 @@ class DayCanonicalFormSerializer(serializers.Serializer):
     '''
     obj = DaySerializer()
     set_list = WorkoutCanonicalFormExerciseSerializer(many=True)
-    days_of_week = serializers.ReadOnlyField()
+    days_of_week = DaysOfWeekCanonicalFormSerializer()
     muscles = serializers.ReadOnlyField()
 
 

--- a/wger/manager/api/serializers.py
+++ b/wger/manager/api/serializers.py
@@ -17,7 +17,7 @@
 
 from rest_framework import serializers
 
-from wger.manager.models import Workout
+from wger.manager.models import Workout, ScheduleStep
 from wger.manager.models import Day
 from wger.manager.models import Setting
 from wger.manager.models import Set
@@ -52,6 +52,14 @@ class WorkoutLogSerializer(serializers.ModelSerializer):
     class Meta:
         model = WorkoutLog
         exclude = ('user',)
+
+
+class ScheduleStepSerializer(serializers.ModelSerializer):
+    '''
+    ScheduleStep serializer
+    '''
+    class Meta:
+        model = ScheduleStep
 
 
 class ScheduleSerializer(serializers.ModelSerializer):
@@ -97,9 +105,9 @@ class WorkoutCanonicalFormExerciseListSerializer(serializers.Serializer):
     Serializer for settings in the canonical form of a workout
     '''
     setting_obj_list = SettingSerializer(many=True)
-    setting_list = serializers.Field()
-    setting_text = serializers.Field()
-    comment_list = serializers.Field()
+    setting_list = serializers.ReadOnlyField()
+    setting_text = serializers.ReadOnlyField()
+    comment_list = serializers.ReadOnlyField()
 
 
 class WorkoutCanonicalFormExerciseSerializer(serializers.Serializer):
@@ -110,7 +118,7 @@ class WorkoutCanonicalFormExerciseSerializer(serializers.Serializer):
     exercise_list = WorkoutCanonicalFormExerciseListSerializer()
     has_settings = serializers.BooleanField()
     is_superset = serializers.BooleanField()
-    muscles = serializers.Field()
+    muscles = serializers.ReadOnlyField()
 
 
 class DayCanonicalFormSerializer(serializers.Serializer):
@@ -119,8 +127,8 @@ class DayCanonicalFormSerializer(serializers.Serializer):
     '''
     obj = DaySerializer()
     set_list = WorkoutCanonicalFormExerciseSerializer(many=True)
-    days_of_week = serializers.Field()
-    muscles = serializers.Field()
+    days_of_week = serializers.ReadOnlyField()
+    muscles = serializers.ReadOnlyField()
 
 
 class WorkoutCanonicalFormSerializer(serializers.Serializer):
@@ -128,5 +136,5 @@ class WorkoutCanonicalFormSerializer(serializers.Serializer):
     Serializer for the canonical form of a workout
     '''
     obj = WorkoutSerializer()
-    muscles = serializers.Field()
+    muscles = serializers.ReadOnlyField()
     day_list = DayCanonicalFormSerializer(many=True)

--- a/wger/manager/api/views.py
+++ b/wger/manager/api/views.py
@@ -19,7 +19,7 @@ import datetime
 
 from rest_framework import viewsets
 from rest_framework.response import Response
-from rest_framework.decorators import link
+from rest_framework.decorators import detail_route
 
 from wger.manager.api.serializers import WorkoutSerializer
 from wger.manager.api.serializers import WorkoutCanonicalFormSerializer
@@ -64,7 +64,7 @@ class WorkoutViewSet(viewsets.ModelViewSet):
         '''
         obj.user = self.request.user
 
-    @link()
+    @detail_route()
     def canonical_representation(self, request, pk):
         '''
         Output the canonical representation of a workout

--- a/wger/manager/api/views.py
+++ b/wger/manager/api/views.py
@@ -63,12 +63,6 @@ class WorkoutViewSet(viewsets.ModelViewSet):
         '''
         serializer.save(user=self.request.user)
 
-    def perform_update(self, serializer):
-        '''
-        Set the owner
-        '''
-        serializer.save(user=self.request.user)
-
     @detail_route()
     def canonical_representation(self, request, pk):
         '''
@@ -102,13 +96,6 @@ class WorkoutSessionViewSet(WgerOwnerObjectModelViewSet):
         return WorkoutSession.objects.filter(user=self.request.user)
 
     def perform_create(self, serializer):
-        '''
-        Set the owner
-        '''
-        today = datetime.date.today()
-        serializer.save(date=today, user=self.request.user)
-
-    def perform_update(self, serializer):
         '''
         Set the owner
         '''
@@ -167,12 +154,6 @@ class ScheduleViewSet(viewsets.ModelViewSet):
         return Schedule.objects.filter(user=self.request.user)
 
     def perform_create(self, serializer):
-        '''
-        Set the owner
-        '''
-        serializer.save(user=self.request.user)
-
-    def perform_update(self, serializer):
         '''
         Set the owner
         '''
@@ -253,12 +234,6 @@ class SettingViewSet(WgerOwnerObjectModelViewSet):
         '''
         serializer.save(order=1)
 
-    def perform_update(self, serializer):
-        '''
-        Set the order
-        '''
-        serializer.save(order=1)
-
     def get_owner_objects(self):
         '''
         Return objects to check for ownership permission
@@ -287,12 +262,6 @@ class WorkoutLogViewSet(WgerOwnerObjectModelViewSet):
         return WorkoutLog.objects.filter(user=self.request.user)
 
     def perform_create(self, serializer):
-        '''
-        Set the owner
-        '''
-        serializer.save(user=self.request.user)
-
-    def perform_update(self, serializer):
         '''
         Set the owner
         '''

--- a/wger/manager/api/views.py
+++ b/wger/manager/api/views.py
@@ -45,7 +45,6 @@ class WorkoutViewSet(viewsets.ModelViewSet):
     '''
     API endpoint for workout objects
     '''
-    model = Workout
     serializer_class = WorkoutSerializer
     is_private = True
     ordering_fields = '__all__'
@@ -86,7 +85,6 @@ class WorkoutSessionViewSet(WgerOwnerObjectModelViewSet):
     '''
     API endpoint for workout sessions objects
     '''
-    model = WorkoutSession
     serializer_class = WorkoutSessionSerializer
     is_private = True
     ordering_fields = '__all__'
@@ -128,8 +126,6 @@ class ScheduleStepViewSet(WgerOwnerObjectModelViewSet):
     '''
     API endpoint for schedule step objects
     '''
-
-    model = ScheduleStep
     serializer_class = ScheduleStepSerializer
     is_private = True
     ordering_fields = '__all__'
@@ -156,7 +152,6 @@ class ScheduleViewSet(viewsets.ModelViewSet):
     '''
     API endpoint for schedule objects
     '''
-    model = Schedule
     serializer_class = ScheduleSerializer
     is_private = True
     ordering_fields = '__all__'
@@ -188,7 +183,6 @@ class DayViewSet(WgerOwnerObjectModelViewSet):
     '''
     API endpoint for training day objects
     '''
-    model = Day
     serializer_class = DaySerializer
     is_private = True
     ordering_fields = '__all__'
@@ -213,7 +207,6 @@ class SetViewSet(WgerOwnerObjectModelViewSet):
     '''
     API endpoint for workout set objects
     '''
-    model = Set
     serializer_class = SetSerializer
     is_private = True
     ordering_fields = '__all__'
@@ -239,7 +232,6 @@ class SettingViewSet(WgerOwnerObjectModelViewSet):
     '''
     API endpoint for repetition setting objects
     '''
-    model = Setting
     serializer_class = SettingSerializer
     is_private = True
     ordering_fields = '__all__'
@@ -278,7 +270,6 @@ class WorkoutLogViewSet(WgerOwnerObjectModelViewSet):
     '''
     API endpoint for workout log objects
     '''
-    model = WorkoutLog
     serializer_class = WorkoutLogSerializer
     is_private = True
     ordering_fields = '__all__'

--- a/wger/manager/api/views.py
+++ b/wger/manager/api/views.py
@@ -21,7 +21,7 @@ from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.decorators import detail_route
 
-from wger.manager.api.serializers import WorkoutSerializer
+from wger.manager.api.serializers import WorkoutSerializer, ScheduleStepSerializer
 from wger.manager.api.serializers import WorkoutCanonicalFormSerializer
 from wger.manager.api.serializers import DaySerializer
 from wger.manager.api.serializers import SettingSerializer
@@ -58,11 +58,17 @@ class WorkoutViewSet(viewsets.ModelViewSet):
         '''
         return Workout.objects.filter(user=self.request.user)
 
-    def pre_save(self, obj):
+    def perform_create(self, serializer):
         '''
         Set the owner
         '''
-        obj.user = self.request.user
+        serializer.save(user=self.request.user)
+
+    def perform_update(self, serializer):
+        '''
+        Set the owner
+        '''
+        serializer.save(user=self.request.user)
 
     @detail_route()
     def canonical_representation(self, request, pk):
@@ -97,12 +103,19 @@ class WorkoutSessionViewSet(WgerOwnerObjectModelViewSet):
         '''
         return WorkoutSession.objects.filter(user=self.request.user)
 
-    def pre_save(self, obj):
+    def perform_create(self, serializer):
         '''
         Set the owner
         '''
-        obj.date = datetime.date.today()  # TODO: actually, this should be editable
-        obj.user = self.request.user
+        today = datetime.date.today()
+        serializer.save(date=today, user=self.request.user)
+
+    def perform_update(self, serializer):
+        '''
+        Set the owner
+        '''
+        today = datetime.date.today()
+        serializer.save(date=today, user=self.request.user)
 
     def get_owner_objects(self):
         '''
@@ -117,6 +130,7 @@ class ScheduleStepViewSet(WgerOwnerObjectModelViewSet):
     '''
 
     model = ScheduleStep
+    serializer_class = ScheduleStepSerializer
     is_private = True
     ordering_fields = '__all__'
     filter_fields = ('schedule',
@@ -157,11 +171,17 @@ class ScheduleViewSet(viewsets.ModelViewSet):
         '''
         return Schedule.objects.filter(user=self.request.user)
 
-    def pre_save(self, obj):
+    def perform_create(self, serializer):
         '''
-        Set the order
+        Set the owner
         '''
-        obj.user = self.request.user
+        serializer.save(user=self.request.user)
+
+    def perform_update(self, serializer):
+        '''
+        Set the owner
+        '''
+        serializer.save(user=self.request.user)
 
 
 class DayViewSet(WgerOwnerObjectModelViewSet):
@@ -235,11 +255,17 @@ class SettingViewSet(WgerOwnerObjectModelViewSet):
         '''
         return Setting.objects.filter(set__exerciseday__training__user=self.request.user)
 
-    def pre_save(self, obj):
+    def perform_create(self, serializer):
         '''
         Set the order
         '''
-        obj.order = 1
+        serializer.save(order=1)
+
+    def perform_update(self, serializer):
+        '''
+        Set the order
+        '''
+        serializer.save(order=1)
 
     def get_owner_objects(self):
         '''
@@ -269,11 +295,17 @@ class WorkoutLogViewSet(WgerOwnerObjectModelViewSet):
 
         return WorkoutLog.objects.filter(user=self.request.user)
 
-    def pre_save(self, obj):
+    def perform_create(self, serializer):
         '''
-        Set the order
+        Set the owner
         '''
-        obj.user = self.request.user
+        serializer.save(user=self.request.user)
+
+    def perform_update(self, serializer):
+        '''
+        Set the owner
+        '''
+        serializer.save(user=self.request.user)
 
     def get_owner_objects(self):
         '''

--- a/wger/nutrition/api/serializers.py
+++ b/wger/nutrition/api/serializers.py
@@ -51,6 +51,8 @@ class MealItemSerializer(serializers.ModelSerializer):
     '''
     MealItem serializer
     '''
+    meal = serializers.PrimaryKeyRelatedField(label='Nutrition plan',
+                                              queryset=Meal.objects.all())
 
     class Meta:
         model = MealItem
@@ -60,6 +62,8 @@ class MealSerializer(serializers.ModelSerializer):
     '''
     Meal serializer
     '''
+    plan = serializers.PrimaryKeyRelatedField(label='Nutrition plan',
+                                              queryset=NutritionPlan.objects.all())
 
     class Meta:
         model = Meal

--- a/wger/nutrition/api/serializers.py
+++ b/wger/nutrition/api/serializers.py
@@ -16,7 +16,7 @@
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
 from rest_framework import serializers
-from wger.nutrition.models import NutritionPlan
+from wger.nutrition.models import NutritionPlan, IngredientWeightUnit, WeightUnit, MealItem, Meal, Ingredient
 
 
 class NutritionPlanSerializer(serializers.ModelSerializer):
@@ -27,3 +27,48 @@ class NutritionPlanSerializer(serializers.ModelSerializer):
     class Meta:
         model = NutritionPlan
         exclude = ('user',)
+
+
+class IngredientWeightUnitSerializer(serializers.ModelSerializer):
+    '''
+    IngredientWeightUnit serializer
+    '''
+
+    class Meta:
+        model = IngredientWeightUnit
+
+
+class WeightUnitSerializer(serializers.ModelSerializer):
+    '''
+    WeightUnit serializer
+    '''
+
+    class Meta:
+        model = WeightUnit
+
+
+class MealItemSerializer(serializers.ModelSerializer):
+    '''
+    MealItem serializer
+    '''
+
+    class Meta:
+        model = MealItem
+
+
+class MealSerializer(serializers.ModelSerializer):
+    '''
+    Meal serializer
+    '''
+
+    class Meta:
+        model = Meal
+
+
+class IngredientSerializer(serializers.ModelSerializer):
+    '''
+    Ingredient serializer
+    '''
+
+    class Meta:
+        model = Ingredient

--- a/wger/nutrition/api/serializers.py
+++ b/wger/nutrition/api/serializers.py
@@ -16,7 +16,8 @@
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
 from rest_framework import serializers
-from wger.nutrition.models import NutritionPlan, IngredientWeightUnit, WeightUnit, MealItem, Meal, Ingredient
+from wger.nutrition.models import NutritionPlan, IngredientWeightUnit, \
+    WeightUnit, MealItem, Meal, Ingredient
 
 
 class NutritionPlanSerializer(serializers.ModelSerializer):

--- a/wger/nutrition/api/views.py
+++ b/wger/nutrition/api/views.py
@@ -16,7 +16,7 @@
 # along with Workout Manager.  If not, see <http://www.gnu.org/licenses/>.
 
 from rest_framework import viewsets
-from rest_framework.decorators import link
+from rest_framework.decorators import detail_route
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
@@ -58,7 +58,7 @@ class IngredientViewSet(viewsets.ReadOnlyModelViewSet):
                      'license',
                      'license_author')
 
-    @link()
+    @detail_route()
     def get_values(self, request, pk):
         '''
         Calculates the nutritional values for current ingredient and
@@ -180,7 +180,7 @@ class NutritionPlanViewSet(viewsets.ModelViewSet):
         obj.user = self.request.user
         obj.language = load_language()
 
-    @link()
+    @detail_route()
     def nutritional_values(self, request, pk):
         '''
         Return an overview of the nutritional plan's values
@@ -217,7 +217,7 @@ class MealViewSet(WgerOwnerObjectModelViewSet):
         '''
         return [(NutritionPlan, 'plan')]
 
-    @link()
+    @detail_route()
     def nutritional_values(self, request, pk):
         '''
         Return an overview of the nutritional plan's values
@@ -256,7 +256,7 @@ class MealItemViewSet(WgerOwnerObjectModelViewSet):
         '''
         return [(Meal, 'meal')]
 
-    @link()
+    @detail_route()
     def nutritional_values(self, request, pk):
         '''
         Return an overview of the nutritional plan's values

--- a/wger/nutrition/api/views.py
+++ b/wger/nutrition/api/views.py
@@ -186,12 +186,6 @@ class NutritionPlanViewSet(viewsets.ModelViewSet):
         '''
         serializer.save(user=self.request.user, language=load_language())
 
-    def perform_update(self, serializer):
-        '''
-        Set the owner
-        '''
-        serializer.save(user=self.request.user, language=load_language())
-
     @detail_route()
     def nutritional_values(self, request, pk):
         '''
@@ -218,12 +212,6 @@ class MealViewSet(WgerOwnerObjectModelViewSet):
         return Meal.objects.filter(plan__user=self.request.user)
 
     def perform_create(self, serializer):
-        '''
-        Set the order
-        '''
-        serializer.save(order=1)
-
-    def perform_update(self, serializer):
         '''
         Set the order
         '''
@@ -263,12 +251,6 @@ class MealItemViewSet(WgerOwnerObjectModelViewSet):
         return MealItem.objects.filter(meal__plan__user=self.request.user)
 
     def perform_create(self, serializer):
-        '''
-        Set the order
-        '''
-        serializer.save(order=1)
-
-    def perform_update(self, serializer):
         '''
         Set the order
         '''

--- a/wger/nutrition/api/views.py
+++ b/wger/nutrition/api/views.py
@@ -20,7 +20,8 @@ from rest_framework.decorators import detail_route
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from wger.nutrition.api.serializers import NutritionPlanSerializer
+from wger.nutrition.api.serializers import NutritionPlanSerializer, IngredientWeightUnitSerializer, WeightUnitSerializer, \
+    MealItemSerializer, MealSerializer, IngredientSerializer
 from wger.nutrition.forms import UnitChooserForm
 
 from wger.nutrition.models import Ingredient
@@ -39,7 +40,8 @@ class IngredientViewSet(viewsets.ReadOnlyModelViewSet):
     '''
     API endpoint for ingredient objects
     '''
-    model = Ingredient
+    queryset = Ingredient.objects.all()
+    serializer_class = IngredientSerializer
     ordering_fields = '__all__'
     filter_fields = ('carbohydrates',
                      'carbohydrates_sugar',
@@ -136,7 +138,8 @@ class WeightUnitViewSet(viewsets.ReadOnlyModelViewSet):
     '''
     API endpoint for weight unit objects
     '''
-    model = WeightUnit
+    queryset = WeightUnit.objects.all()
+    serializer_class = WeightUnitSerializer
     ordering_fields = '__all__'
     filter_fields = ('language',
                      'name')
@@ -146,7 +149,8 @@ class IngredientWeightUnitViewSet(viewsets.ReadOnlyModelViewSet):
     '''
     API endpoint for many-to-many table ingredient-weight unit objects
     '''
-    model = IngredientWeightUnit
+    queryset = IngredientWeightUnit.objects.all()
+    serializer_class = IngredientWeightUnitSerializer
     ordering_fields = '__all__'
     filter_fields = ('amount',
                      'gram',
@@ -173,12 +177,17 @@ class NutritionPlanViewSet(viewsets.ModelViewSet):
         '''
         return NutritionPlan.objects.filter(user=self.request.user)
 
-    def pre_save(self, obj):
+    def perform_create(self, serializer):
         '''
         Set the owner
         '''
-        obj.user = self.request.user
-        obj.language = load_language()
+        serializer.save(user=self.request.user, language=load_language())
+
+    def perform_update(self, serializer):
+        '''
+        Set the owner
+        '''
+        serializer.save(user=self.request.user, language=load_language())
 
     @detail_route()
     def nutritional_values(self, request, pk):
@@ -193,6 +202,7 @@ class MealViewSet(WgerOwnerObjectModelViewSet):
     API endpoint for meal objects
     '''
     model = Meal
+    serializer_class = MealSerializer
     is_private = True
     ordering_fields = '__all__'
     filter_fields = ('order',
@@ -205,11 +215,17 @@ class MealViewSet(WgerOwnerObjectModelViewSet):
         '''
         return Meal.objects.filter(plan__user=self.request.user)
 
-    def pre_save(self, obj):
+    def perform_create(self, serializer):
         '''
         Set the order
         '''
-        obj.order = 1
+        serializer.save(order=1)
+
+    def perform_update(self, serializer):
+        '''
+        Set the order
+        '''
+        serializer.save(order=1)
 
     def get_owner_objects(self):
         '''
@@ -230,6 +246,7 @@ class MealItemViewSet(WgerOwnerObjectModelViewSet):
     API endpoint for meal item objects
     '''
     model = MealItem
+    serializer_class = MealItemSerializer
     is_private = True
     ordering_fields = '__all__'
     filter_fields = ('amount',
@@ -244,11 +261,17 @@ class MealItemViewSet(WgerOwnerObjectModelViewSet):
         '''
         return MealItem.objects.filter(meal__plan__user=self.request.user)
 
-    def pre_save(self, obj):
+    def perform_create(self, serializer):
         '''
         Set the order
         '''
-        obj.order = 1
+        serializer.save(order=1)
+
+    def perform_update(self, serializer):
+        '''
+        Set the order
+        '''
+        serializer.save(order=1)
 
     def get_owner_objects(self):
         '''

--- a/wger/nutrition/api/views.py
+++ b/wger/nutrition/api/views.py
@@ -98,6 +98,9 @@ class IngredientViewSet(viewsets.ReadOnlyModelViewSet):
             item.amount = form.cleaned_data['amount']
 
             result = item.get_nutritional_values()
+
+            for i in result:
+                result[i] = '{0:f}'.format(result[i])
         else:
             result['errors'] = form.errors
 

--- a/wger/nutrition/api/views.py
+++ b/wger/nutrition/api/views.py
@@ -165,7 +165,6 @@ class NutritionPlanViewSet(viewsets.ModelViewSet):
     '''
     API endpoint for nutrition plan objects
     '''
-    model = NutritionPlan
     serializer_class = NutritionPlanSerializer
     is_private = True
     ordering_fields = '__all__'
@@ -204,7 +203,6 @@ class MealViewSet(WgerOwnerObjectModelViewSet):
     '''
     API endpoint for meal objects
     '''
-    model = Meal
     serializer_class = MealSerializer
     is_private = True
     ordering_fields = '__all__'
@@ -248,7 +246,6 @@ class MealItemViewSet(WgerOwnerObjectModelViewSet):
     '''
     API endpoint for meal item objects
     '''
-    model = MealItem
     serializer_class = MealItemSerializer
     is_private = True
     ordering_fields = '__all__'

--- a/wger/nutrition/api/views.py
+++ b/wger/nutrition/api/views.py
@@ -20,8 +20,9 @@ from rest_framework.decorators import detail_route
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from wger.nutrition.api.serializers import NutritionPlanSerializer, IngredientWeightUnitSerializer, WeightUnitSerializer, \
-    MealItemSerializer, MealSerializer, IngredientSerializer
+from wger.nutrition.api.serializers import NutritionPlanSerializer, \
+    IngredientWeightUnitSerializer, WeightUnitSerializer, MealItemSerializer, \
+    MealSerializer, IngredientSerializer
 from wger.nutrition.forms import UnitChooserForm
 
 from wger.nutrition.models import Ingredient

--- a/wger/urls.py
+++ b/wger/urls.py
@@ -82,39 +82,39 @@ v1_api.register(core_api.LicenseResource())
 router = routers.DefaultRouter()
 
 # Manager app
-router.register(r'workout', manager_api_views.WorkoutViewSet)
-router.register(r'workoutsession', manager_api_views.WorkoutSessionViewSet)
-router.register(r'schedulestep', manager_api_views.ScheduleStepViewSet)
-router.register(r'schedule', manager_api_views.ScheduleViewSet)
-router.register(r'day', manager_api_views.DayViewSet)
-router.register(r'set', manager_api_views.SetViewSet)
-router.register(r'setting', manager_api_views.SettingViewSet)
-router.register(r'workoutlog', manager_api_views.WorkoutLogViewSet)
+router.register(r'workout', manager_api_views.WorkoutViewSet, base_name='workout')
+router.register(r'workoutsession', manager_api_views.WorkoutSessionViewSet, base_name='workoutsession')
+router.register(r'schedulestep', manager_api_views.ScheduleStepViewSet, base_name='schedulestep')
+router.register(r'schedule', manager_api_views.ScheduleViewSet, base_name='schedule')
+router.register(r'day', manager_api_views.DayViewSet, base_name='day')
+router.register(r'set', manager_api_views.SetViewSet, base_name='Set')
+router.register(r'setting', manager_api_views.SettingViewSet, base_name='Setting')
+router.register(r'workoutlog', manager_api_views.WorkoutLogViewSet, base_name='workoutlog')
 
 # Core app
-router.register(r'userprofile', core_api_views.UserProfileViewSet)
-router.register(r'language', core_api_views.LanguageViewSet)
-router.register(r'daysofweek', core_api_views.DaysOfWeekViewSet)
-router.register(r'license', core_api_views.LicenseViewSet)
+router.register(r'userprofile', core_api_views.UserProfileViewSet, base_name='userprofile')
+router.register(r'language', core_api_views.LanguageViewSet, base_name='language')
+router.register(r'daysofweek', core_api_views.DaysOfWeekViewSet, base_name='daysofweek')
+router.register(r'license', core_api_views.LicenseViewSet, base_name='license')
 
 # Exercises app
-router.register(r'exercise', exercises_api_views.ExerciseViewSet)
+router.register(r'exercise', exercises_api_views.ExerciseViewSet, base_name='exercise')
 router.register(r'equipment', exercises_api_views.EquipmentViewSet, base_name='api')
-router.register(r'exercisecategory', exercises_api_views.ExerciseCategoryViewSet)
-router.register(r'exerciseimage', exercises_api_views.ExerciseImageViewSet)
-router.register(r'exercisecomment', exercises_api_views.ExerciseCommentViewSet)
-router.register(r'muscle', exercises_api_views.MuscleViewSet)
+router.register(r'exercisecategory', exercises_api_views.ExerciseCategoryViewSet, base_name='exercisecategory')
+router.register(r'exerciseimage', exercises_api_views.ExerciseImageViewSet, base_name='exerciseimage')
+router.register(r'exercisecomment', exercises_api_views.ExerciseCommentViewSet, base_name='exercisecomment')
+router.register(r'muscle', exercises_api_views.MuscleViewSet, base_name='muscle')
 
 # Nutrition app
 router.register(r'ingredient', nutrition_api_views.IngredientViewSet, base_name='api-ingredient')
-router.register(r'weightunit', nutrition_api_views.WeightUnitViewSet)
-router.register(r'ingredientweightunit', nutrition_api_views.IngredientWeightUnitViewSet)
-router.register(r'nutritionplan', nutrition_api_views.NutritionPlanViewSet)
-router.register(r'meal', nutrition_api_views.MealViewSet)
-router.register(r'mealitem', nutrition_api_views.MealItemViewSet)
+router.register(r'weightunit', nutrition_api_views.WeightUnitViewSet, base_name='weightunit')
+router.register(r'ingredientweightunit', nutrition_api_views.IngredientWeightUnitViewSet, base_name='ingredientweightunit')
+router.register(r'nutritionplan', nutrition_api_views.NutritionPlanViewSet, base_name='nutritionplan')
+router.register(r'meal', nutrition_api_views.MealViewSet, base_name='meal')
+router.register(r'mealitem', nutrition_api_views.MealItemViewSet, base_name='mealitem')
 
 # Weight app
-router.register(r'weightentry', weight_api_views.WeightEntryViewSet)
+router.register(r'weightentry', weight_api_views.WeightEntryViewSet, base_name='weightentry')
 
 
 from django.contrib import admin

--- a/wger/weight/api/views.py
+++ b/wger/weight/api/views.py
@@ -25,7 +25,6 @@ class WeightEntryViewSet(viewsets.ModelViewSet):
     '''
     API endpoint for nutrition plan objects
     '''
-    model = WeightEntry
     serializer_class = WeightEntrySerializer
     is_private = True
     ordering_fields = '__all__'

--- a/wger/weight/api/views.py
+++ b/wger/weight/api/views.py
@@ -38,8 +38,14 @@ class WeightEntryViewSet(viewsets.ModelViewSet):
         '''
         return WeightEntry.objects.filter(user=self.request.user)
 
-    def pre_save(self, obj):
+    def perform_create(self, serializer):
         '''
         Set the owner
         '''
-        obj.user = self.request.user
+        serializer.save(user=self.request.user)
+
+    def perform_update(self, serializer):
+        '''
+        Set the owner
+        '''
+        serializer.save(user=self.request.user)

--- a/wger/weight/api/views.py
+++ b/wger/weight/api/views.py
@@ -42,9 +42,3 @@ class WeightEntryViewSet(viewsets.ModelViewSet):
         Set the owner
         '''
         serializer.save(user=self.request.user)
-
-    def perform_update(self, serializer):
-        '''
-        Set the owner
-        '''
-        serializer.save(user=self.request.user)


### PR DESCRIPTION
Hi @rolandgeider ,

I'm finished with the upgrade. If you have time then please review the pull request.

There a lot of changes:

1. Added a serializer and a queryset where it was missing, and removed the model attributes (model are attributes are removed from 3X).

2. The link decorator is renamed to detail_route.

3. pre_save methods are not available, there are perform_create and perform_update methods, but these are working with values instead of objects. Because of this I left a TODO at the ExerciseViewSet and ExerciseImageViewSet perform_create. You can't call a model method before saving to the db. 
I'm calling the set_author after the save now, but it does not seem to a good solution. 
Do you have any idea for this?

4. Because the IngredientViewSet get_values not using the Serializer I needed to coerce the float values manually to string. 

5. In some models the foreign keys are not editable (MealItem), because of this the ModelSerializer sets these fields readonly. I needed to add these fields manually for the model serializers to enable setting the values from the API.