### PR TITLE
Fix inaccurate wording

### DIFF
--- a/wger/core/forms.py
+++ b/wger/core/forms.py
@@ -42,7 +42,7 @@ class UserPreferencesForm(forms.ModelForm):
 
 class UserEmailForm(forms.ModelForm):
     email = EmailField(label=_("Email"),
-                       help_text=_("Only needed to reset your password in case you forget it."),
+                       help_text=_("Used for password resets and, optionally, workout reminders."),
                        required=False)
 
     class Meta:

--- a/wger/core/forms.py
+++ b/wger/core/forms.py
@@ -42,7 +42,7 @@ class UserPreferencesForm(forms.ModelForm):
 
 class UserEmailForm(forms.ModelForm):
     email = EmailField(label=_("Email"),
-                       help_text=_("Used for password resets and, optionally, workout reminders."),
+                       help_text=_("Used for password resets and, optionally, email reminders."),
                        required=False)
 
     class Meta:


### PR DESCRIPTION
Previous wording indicated that email was only used for reseting
passwords, but the app also supports email reminders.

Updated wording takes into account these two uses for email addresses.