### PR TITLE
Add height as a DecimalField to BmiForm

### DIFF
--- a/wger/nutrition/forms.py
+++ b/wger/nutrition/forms.py
@@ -55,6 +55,8 @@ class UnitChooserForm(forms.Form):
 
 
 class BmiForm(forms.ModelForm):
+    height = forms.DecimalField(widget=Html5NumberInput(),
+                                max_value=999)
     weight = forms.DecimalField(widget=Html5NumberInput(),
                                 max_value=999)
 

--- a/wger/nutrition/forms.py
+++ b/wger/nutrition/forms.py
@@ -56,7 +56,8 @@ class UnitChooserForm(forms.Form):
 
 class BmiForm(forms.ModelForm):
     height = forms.DecimalField(widget=Html5NumberInput(),
-                                max_value=999)
+                                max_value=999,
+                                label=_('Height (cm)'))
     weight = forms.DecimalField(widget=Html5NumberInput(),
                                 max_value=999)
 


### PR DESCRIPTION
If the form got a floating point value in the height field, then
the validation failed. Because of this the bmi calculation didn't
return anything. Fixes #146