### PR TITLE
Activate localization for share buttons

### DIFF
--- a/wger/core/templates/misc/fragments/shariff_modal.html
+++ b/wger/core/templates/misc/fragments/shariff_modal.html
@@ -7,7 +7,7 @@
                 <h4 class="modal-title">{% trans "Share this page" %}</h4>
             </div>
             <div class="modal-body">
-                <div class="shariff {% if is_owner and not owner_user.userprofile.ro_access %}hidden{% endif %}"></div>
+                <div class="shariff {% if is_owner and not owner_user.userprofile.ro_access %}hidden{% endif %}" data-lang="{{language.short_name}}"></div>
 
                 {% if owner_user %}
                 <div class="noRoAccess {% if user.is_authenticated and is_owner and owner_user.userprofile.ro_access %}hidden{% endif %}">


### PR DESCRIPTION
Set `data-lang`attribute, so share buttons will be translated. However, if the current language isn't supported by shariff, it will [fallback to English](https://github.com/heiseonline/shariff/blob/master/src/js/shariff.js#L72).